### PR TITLE
Add MPS (Apple silicon) auto-detection to inference.py

### DIFF
--- a/coreml/README.md
+++ b/coreml/README.md
@@ -1,5 +1,14 @@
 # CoreML model export
 
+The scripts below work, but at the moment the CoreML export is not quantized, and runs ~8x more slowly than running the PyTorch model with the torch Apple Silicon `mps` backend.
+
+So for now, it's better to use the PyTorch model on Apple Silicon. It would be great to figure out how to produce an optimized CoreML model. At the moment, the blockers are:
+  - ANECompilerService runs forever at 100% CPU when trying to export to fp16 with compute_units=ct.ComputeUnit.ALL, or when trying to load an exported model with any setting *other* than compute_units=ct.ComputeUnit.CPU_ONLY
+  - When running in CPU_ONLY mode, both the fp32 and fp16 models run reasonably fast, but still 50% slower than the torch mps backend.
+  - When running in CPU_ONLY mode, there is an interaction with Python asyncio that causes segfaults. We spent quite a bit of time trying to narrow down the cause of this and formulate a workaround, but have not been completely successful here.
+
+## ... old ...
+
 Work in progress towards producing a performant coreml modal automatically from PyTorch model checkpoints.
 
 The coreml model package is in the [coreml directory of the Hugging Face](https://huggingface.co/pipecat-ai/smart-turn/tree/main/coreml) repo.

--- a/coreml/test-coreml-predict.py
+++ b/coreml/test-coreml-predict.py
@@ -4,7 +4,7 @@ import coremltools as ct
 import numpy as np
 from transformers import Wav2Vec2Processor
 
-MODEL_PATH = "smart_turn_classifier_fp16.mlpackage"
+MODEL_PATH = "smart_turn_classifier.mlpackage"
 TORCH_MODEL_PATH = "pipecat-ai/smart-turn-v2"
 
 print("Loading Core ML model …")

--- a/coreml/test-coreml-predict.py
+++ b/coreml/test-coreml-predict.py
@@ -4,12 +4,12 @@ import coremltools as ct
 import numpy as np
 from transformers import Wav2Vec2Processor
 
-MODEL_PATH = "smart_turn_classifier.mlpackage"
+MODEL_PATH = "smart_turn_classifier_fp16.mlpackage"
 TORCH_MODEL_PATH = "pipecat-ai/smart-turn-v2"
 
 print("Loading Core ML model …")
 start_time = time.perf_counter()
-mlmodel = ct.models.MLModel(MODEL_PATH)
+mlmodel = ct.models.MLModel(MODEL_PATH, compute_units=ct.ComputeUnit.CPU_ONLY)
 print(f"Model loaded in {time.perf_counter() - start_time:.2f}s")
 
 # Create a random 8-second audio clip at 16 kHz

--- a/inference.py
+++ b/inference.py
@@ -9,8 +9,13 @@ MODEL_PATH = "pipecat-ai/smart-turn-v2"
 model = Wav2Vec2ForEndpointing.from_pretrained(MODEL_PATH)
 processor = Wav2Vec2Processor.from_pretrained(MODEL_PATH)
 
-# Set model to evaluation mode and move to GPU if available
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+# Set model to evaluation mode and move to platform-optimized backend if available.
+# MPS for Apple silicon, CUDA for NVIDIA.
+device = "cpu"
+if torch.backends.mps.is_available():
+    device = "mps"
+elif torch.cuda.is_available():
+    device = "cuda"
 model = model.to(device)
 model.eval()
 

--- a/record_and_predict.py
+++ b/record_and_predict.py
@@ -145,11 +145,14 @@ def process_speech_segment(audio_buffer, speech_start_time, speech_stop_time):
         print(f"Processing speech segment of length {len(segment_audio) / RATE:.2f} seconds...")
 
         # Call the new predict_endpoint function with the audio data
+        start_time = time.perf_counter()
         result = predict_endpoint(segment_audio_resampled)
+        end_time = time.perf_counter()
 
         print("--------")
         print(f"Prediction: {'Complete' if result['prediction'] == 1 else 'Incomplete'}")
         print(f"Probability of complete: {result['probability']:.4f}")
+        print(f"Prediction took {(end_time - start_time) * 1000:.2f}ms seconds")
     else:
         print("Captured empty audio segment, skipping prediction.")
 


### PR DESCRIPTION
After a bunch of futzing around with CoreML, it turns out the the MPS backend for PyTorch runs the torch model faster than any CoreML export I've managed to produce so far.

This PR uses the torch MPS backend if it's available. (Same auto-detection logic as we currently use for CUDA.)